### PR TITLE
Add support to override region and profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Available Commands:
   tail         Tail records from a Kinesis Data Stream
 
 Flags:
-  -h, --help   help for kin
+  -h, --help             help for kin
+  -p, --profile string   AWS Profile Name
+  -r, --region string    AWS Region Name
 
 Use "kin [command] --help" for more information about a command.
 ```

--- a/cmd/list-shards.go
+++ b/cmd/list-shards.go
@@ -25,8 +25,10 @@ var listShardsCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		streamName, _ := cmd.Flags().GetString("stream-name")
+		profile , _ := cmd.Flags().GetString("profile")
+		region , _ := cmd.Flags().GetString("region")
 
-		client, err := aws.GetKinesisClient()
+		client, err := aws.GetKinesisClient(aws.WithProfile(profile), aws.WithRegion(region))
 		if err != nil {
 			cmd.PrintErrln(err)
 			os.Exit(1)

--- a/cmd/list-streams.go
+++ b/cmd/list-streams.go
@@ -20,7 +20,10 @@ var listStreamsCmd = &cobra.Command{
 	Short:   "List Kinesis streams",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := aws.GetKinesisClient()
+		profile , _ := cmd.Flags().GetString("profile")
+		region , _ := cmd.Flags().GetString("region")
+
+		client, err := aws.GetKinesisClient(aws.WithProfile(profile), aws.WithRegion(region))
 		if err != nil {
 			cmd.Println(err)
 			os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,11 @@ var rootCmd = &cobra.Command{
 	Short: "A friendly CLI for working with Amazon Kinesis",
 }
 
+func init() {
+	rootCmd.PersistentFlags().StringP("profile", "p", "", "AWS Profile Name")
+	rootCmd.PersistentFlags().StringP("region", "r", "", "AWS Region Name")
+}
+
 func Execute() error {
 	return rootCmd.Execute()
 }

--- a/cmd/tail.go
+++ b/cmd/tail.go
@@ -48,13 +48,15 @@ deserialized as JSON if possible; otherwise it will be returned as a base64-enco
 func runTailCmd(cmd *cobra.Command, args []string) {
 	streamName, _ := cmd.Flags().GetString("stream-name")
 	shardId, _ := cmd.Flags().GetString("shard")
+	profile , _ := cmd.Flags().GetString("profile")
+	region , _ := cmd.Flags().GetString("region")
 	tailOptions, err := parseTailOpts(cmd.Flags())
 	if err != nil {
 		cmd.PrintErrln(err)
 		os.Exit(1)
 	}
 
-	client, err := aws.GetKinesisClient()
+	client, err := aws.GetKinesisClient(aws.WithProfile(profile), aws.WithRegion(region))
 	if err != nil {
 		cmd.PrintErrln(err)
 		os.Exit(1)

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -7,8 +7,16 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 )
 
-func GetKinesisClient() (*kinesis.Client, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+func WithProfile(profile string) config.LoadOptionsFunc {
+	return config.WithSharedConfigProfile(profile)
+}
+
+func WithRegion(region string) config.LoadOptionsFunc {
+	return config.WithRegion(region)
+}
+
+func GetKinesisClient(cfgOpts ...func(*config.LoadOptions) error) (*kinesis.Client, error) {
+	cfg, err := config.LoadDefaultConfig(context.Background(), cfgOpts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Overview
Allow overriding profile and region with global CLI arguments (jmccance/kin#2)

- Added `-p` and `--profile` global flag
  - Will default to use the `region` defined in your profile
- Added `-r` and `--region` global flag
  - If provided, will override any `region` set in your profile
- Updated `README`

### Examples
Assuming the following `~/.aws/config`:
```
[profile test-profile]
region: us-east-1
...
```

```
# No profile or region
$ kin ls
operation error Kinesis: ListStreams, failed to resolve service endpoint, an AWS region is required, but was not found
exit status 1

# Use default region from profile
$ kin --profile test-profile ls
[list of streams in us-east-1...]

# Override profile region with a bad value
$ kin --profile test-profile --region us-east-99 ls
operation error Kinesis: ListStreams, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , request send failed, Post "https://kinesis.us-east-99.amazonaws.com/": dial tcp: lookup kinesis.us-east-99.amazonaws.com: no such host
exit status 1

# Override profile region
$ kin --profile test-profile --region us-west-1 ls
[list of streams in us-west-1...]
```